### PR TITLE
Adds a Finish dialog.

### DIFF
--- a/app/elements.html
+++ b/app/elements.html
@@ -9,7 +9,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 -->
 
 <!-- Iron elements -->
-<link rel="import" href="bower_components/iron-flex-layout/classes/iron-flex-layout.html">
+<link rel="import" href="bower_components/iron-flex-layout/iron-flex-layout-classes.html">
 <link rel="import" href="bower_components/iron-icons/iron-icons.html">
 <link rel="import" href="bower_components/iron-pages/iron-pages.html">
 <link rel="import" href="bower_components/iron-ajax/iron-ajax.html">

--- a/app/elements/assignment-create-panel/card-assignment-create-panel.html
+++ b/app/elements/assignment-create-panel/card-assignment-create-panel.html
@@ -74,7 +74,7 @@
     </template>
 
     <div>
-      <span class="error" hidden$="{{!error}}">One of the fields is filled in.</span>
+      <span class="error" hidden$="{{!error}}">One of the fields is not filled in.</span>
       <paper-button raised on-tap="submit">Submit</paper-button>
     </div>
 

--- a/app/elements/calendar-app.html
+++ b/app/elements/calendar-app.html
@@ -209,6 +209,8 @@
         var fixedEvent = {
           status: event.status,
           assignment: event.assignment,
+          actualLength: event.actualLength,
+          notes: event.notes,
         };
 
         this.$.occurrences.originalEvent = event;

--- a/app/elements/cardlist-api/card-assignment.html
+++ b/app/elements/cardlist-api/card-assignment.html
@@ -12,6 +12,7 @@
       display: block;
       height: auto;
       padding: 10px;
+      background-color: white;
 
       --paper-card-header: {
         background-color: var(--paper-card-header-background-color);

--- a/app/elements/edit-event-modal/edit-event-modal.html
+++ b/app/elements/edit-event-modal/edit-event-modal.html
@@ -63,6 +63,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <div class="buttons">
             <paper-button tabindex="0" dialog-dismiss class="saveButton"><iron-icon icon="clear"></iron-icon>Close</paper-button>
             <paper-button tabindex="0" dialog-confirm class="cancelButton" on-tap="unfinishEvent" title="You have unfinished the assignment"><iron-icon icon="check"></iron-icon>Unfinish</paper-button>
+            <paper-button tabindex="0" dialog-confirm class="finishButton" on-tap="openFinishDialog" title="You have finished the assignment"><iron-icon icon="create"></iron-icon>Edit Notes</paper-button>
           </div>
         </template>
       </div>
@@ -148,7 +149,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this.event.notes = this.notes;
         this.fire('updated', this.event);
       },
-      
+
       saveEvent: function() {
         this.event.title = this.title;
 

--- a/app/elements/edit-event-modal/edit-event-modal.html
+++ b/app/elements/edit-event-modal/edit-event-modal.html
@@ -50,12 +50,15 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           <div class="buttons">
             <paper-button tabindex="0" dialog-dismiss on-tap="saveEvent" raised class="saveButton" title="Save the changes"><iron-icon icon="save"></iron-icon>Save</paper-button>
             <paper-button tabindex="0" dialog-dismiss class="cancelButton" title="Don't save the changes"><iron-icon icon="clear"></iron-icon>Cancel</paper-button>
-            <paper-button tabindex="0" dialog-confirm on-tap="finishEvent" class="finishButton" title="You have finished the assignment"><iron-icon icon="check"></iron-icon>Finish</paper-button>
+            <paper-button tabindex="0" dialog-confirm on-tap="openFinishDialog" class="finishButton" title="You have finished the assignment"><iron-icon icon="check"></iron-icon>Finish</paper-button>
           </div>
         </template>
         <template is="dom-if" if="{{finished}}" restamp="true">
           <paper-toolbar><span>This Occurrence Was Finished</span></paper-toolbar>
-          <span>You finished this occurrence. It took you {{length}} hours.</span>
+          <p>Time planned for this task: {{length}} hours.</p>
+          <p>Time spent on this task: {{event.actualLength}} hours.</p>
+          <h4>Your notes:</h4>
+          <p>{{event.notes}}</p>
 
           <div class="buttons">
             <paper-button tabindex="0" dialog-dismiss class="saveButton"><iron-icon icon="clear"></iron-icon>Close</paper-button>
@@ -64,6 +67,18 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         </template>
       </div>
     </paper-dialog>
+    <paper-dialog id="finishEventDialog" transition="paper-dialog-transition-center" modal>
+      <div>
+          <paper-toolbar><span>Finish Occurrence</span></paper-toolbar>
+          <paper-input label="How many hours did you work?" floatinglabel type="number" value="{{actualLength}}"></paper-input>
+          <paper-input label="Add your notes here..." floatinglabel type="textarea" value="{{notes}}"></paper-input>
+          <div class="buttons">
+            <paper-button tabindex="0" dialog-dismiss on-tap="unfinishEvent" class="unfinishButton" title="un-finish the assignment"><iron-icon icon="undo"></iron-icon>Unfinish</paper-button>
+            <paper-button tabindex="0" dialog-confirm on-tap="finishEvent" class="finishButton" title="Close this window"><iron-icon icon="check"></iron-icon>Save changes</paper-button>
+          </div>
+      </div>
+    </paper-dialog>
+
   </template>
   <script>
   (function() {
@@ -73,7 +88,14 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       properties: {
         event: {
           type: Object
-        }
+        },
+        actualLength: {
+          type: Number
+        },
+        notes : {
+          type: String
+        },
+
       },
 
       ready: function() {
@@ -90,6 +112,7 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
         this.length = moment.duration(
           this.event.end.diff(this.event.start)
         ).asHours();
+        this.actualLength = this.length;
 
         this.$.editEventDialog.open();
 
@@ -97,19 +120,35 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
           this.finished = true;
         }
       },
+
       cancelDialog: function() {
         this.$.editEventDialog.cancel();
       },
+
+      openFinishDialog: function() {
+        this.$.finishEventDialog.open();
+        this.finishEvent();
+      },
+
+      closeFinishDialog: function() {
+        this.$.finishEventDialog.cancel();
+      },
+
       finishEvent: function() {
         this.updateEvent('FINISHED');
       },
+
       unfinishEvent: function() {
         this.updateEvent('UNFINISHED');
       },
+
       updateEvent: function(status) {
         this.event.status = status;
+        this.event.actualLength = this.actualLength;
+        this.event.notes = this.notes;
         this.fire('updated', this.event);
       },
+      
       saveEvent: function() {
         this.event.title = this.title;
 

--- a/app/index.html
+++ b/app/index.html
@@ -52,14 +52,14 @@
 
   <login-popup></login-popup>
 
-  <platinum-sw-register auto-register
+  <!-- <platinum-sw-register auto-register
                       clients-claim
                       skip-waiting
                       on-service-worker-installed="displayInstalledToast">
     <platinum-sw-cache default-cache-strategy="networkFirst"
                        cache-config-file="cache-config.json">
     </platinum-sw-cache>
-  </platinum-sw-register>
+  </platinum-sw-register> -->
 </template>
 </body>
 

--- a/app/styles/app-theme.html
+++ b/app/styles/app-theme.html
@@ -20,10 +20,10 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   :root {
     --dark-primary-color: #303F9F;
     --default-primary-color: #3F51B5;
-    --light-primary-color: #C5CAE9;
+    --light-primary-color: white;
     --text-primary-color: #ffffff; /*text/icons*/
     --accent-color: #FF4081;
-    --primary-background-color: #c5cae9;
+    --primary-background-color: white;
     --primary-text-color: #212121;
     --secondary-text-color: #727272;
     --disabled-text-color: #bdbdbd;

--- a/bower.json
+++ b/bower.json
@@ -2,7 +2,7 @@
   "name": "planningtool",
   "version": "0.1.0",
   "dependencies": {
-    "polymer": "Polymer/Polymer#^1.0.0",
+    "polymer": "Polymer/Polymer#1.2.4",
     "fullcalendar": "~2.4.0",
     "iron-elements": "PolymerElements/iron-elements#^1.0.0",
     "jquery-ui": "~1.11.4",


### PR DESCRIPTION
This PR adds a finish dialog to events. Once in the edit modal the finish button is clicked, a second modal pops up that asks for the actual time spent on this task, as well as an optional note. These are stored in the backend once the edits are confimed.

Some things to note:
- The actual time spent defaults to the time planned for the task. This means users who don't wish to reflect upon their scheduling can just click the accept button and be done with it, without requiring extra form interaction.
- The background of the finish modal is a light blue grey. @TimvdLippe Could this be a paper-dialog bug/feature? It seems to trigger on dialogs opened from within dialogs.
- The second dialog is placed in the same polymer element, as these behaviours work together and complement eachother. I feel seperating them would create complicated structures with dependencies back and forth.

_Warning: this branch corresponds to the [feature/finishDialog](https://github.com/Mentoraat/plannings-tool-server/tree/feature/finishDialog) branch on the server repo, and both should be merged in parallel_
