### PR TITLE
Shadow dom

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -3,10 +3,10 @@
   "version": "0.1.0",
   "dependencies": {
     "polymer": "Polymer/Polymer#1.6.0",
-    "fullcalendar": "2.9.0",
+    "fullcalendar": "^3.0.0",
     "iron-elements": "PolymerElements/iron-elements#^1.0.0",
     "jquery-ui": "~1.12.0",
-    "moment-timezone": "~0.4.0",
+    "moment-timezone": "^0.5.0",
     "neon-elements": "PolymerElements/neon-elements#^1.0.0",
     "page": "visionmedia/page.js#~1.6.3",
     "paper-elements": "PolymerElements/paper-elements#^1.0.1",
@@ -17,7 +17,8 @@
     "paper-tabs": "PolymerElements/paper-tabs#^1.6.2",
     "paper-input": "timvdlippe/paper-input#spinner-mixin",
     "app-route": "polymerelements/app-route#^0.9.2",
-    "iron-lazy-pages": "timvdlippe/iron-lazy-pages#^1.4.1"
+    "iron-lazy-pages": "timvdlippe/iron-lazy-pages#^1.4.1",
+    "moment": "^2.15.2"
   },
   "devDependencies": {
     "web-component-tester": "*",

--- a/index.html
+++ b/index.html
@@ -34,25 +34,62 @@
   <script src='bower_components/moment/min/moment.min.js'></script>
   <script src='bower_components/moment-timezone/builds/moment-timezone-with-data.min.js'></script>
 
-  <script src="bower_components/webcomponentsjs/webcomponents-lite.min.js" async></script>
+  <script>
+    // Setup Polymer options
+    window.Polymer = {
+      // dom: 'shadow',
+      lazyRegister: true
+    };
+    // Load webcomponentsjs polyfill if browser does not support native Web Components
+    (function() {
+      'use strict';
+      var onload = function() {
+        // For native Imports, manually fire WebComponentsReady so user code
+        // can use the same code path for native and polyfill'd imports.
+        if (!window.HTMLImports) {
+          document.dispatchEvent(
+            new CustomEvent('WebComponentsReady', {bubbles: true})
+          );
+        }
+      };
+      var webComponentsSupported = (
+        'registerElement' in document &&
+        'import' in document.createElement('link') &&
+        'content' in document.createElement('template')
+      );
+      if (!webComponentsSupported) {
+        var script = document.createElement('script');
+        script.async = true;
+        script.src = 'bower_components/webcomponentsjs/webcomponents-lite.min.js';
+        script.onload = onload;
+        document.head.appendChild(script);
+      } else {
+        onload();
+      }
+    })();
+    // Load pre-caching Service Worker
+    if ('serviceWorker' in navigator) {
+      window.addEventListener('load', function() {
+        // navigator.serviceWorker.register('/service-worker.js');
+      });
+    }
+  </script>
 
   <link rel="import" href="styles/app-theme.html">
-  <link rel="import" href="src/main-app.html" async>
+  <link rel="import" href="src/main-app.html">
 
   <link rel="stylesheet" href="styles/main.css">
   <style>
-  html, body {
-    margin: 0;
-  }
+    body {
+      margin: 0;
+      font-family: 'Roboto', 'Noto', sans-serif;
+      min-height: 100vh;
+    }
   </style>
 </head>
 
 <body class="fullbleed layout vertical">
-  <span id="browser-sync-binding"></span>
-
-  <template is="dom-bind" id="app">
-    <main-app></main-app>
-</template>
+  <main-app></main-app>
 </body>
 
 </html>

--- a/index.html
+++ b/index.html
@@ -37,7 +37,7 @@
   <script>
     // Setup Polymer options
     window.Polymer = {
-      // dom: 'shadow',
+      dom: 'shadow',
       lazyRegister: true
     };
     // Load webcomponentsjs polyfill if browser does not support native Web Components

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,0 +1,1 @@
+console.info('Service worker disabled for development, will be generated at build time.');


### PR DESCRIPTION
Turn on shadow dom as performance improvement. Luckily fullCalendar works now because jQuery 3.0 fixed shadow dom support :tada: 

TODO:
- [ ] When you directly go to `/app`, ajax are triggered and failing. Need to take a look at this why this is happening.
